### PR TITLE
refactor: remove region input now that OCI_CLI_REGION is required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,15 +16,9 @@ inputs:
       JSON before output.
     required: false
     default: ''
-  region:
-    description: >-
-      (Optional) The region against which to make calls. Defaults to the region
-      specified in the oracle-actions/configure-oci-credentials.
-    required: false
-    default: ''
   silent:
     description: >-
-      (Default: false) If set to False, will stream the output of the command
+      (Default: true) If set to 'False', will stream the output of the command
       directly to the log. This may leak confidential information. We
       recomment keep this as false except for debugging purposes.
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,14 +40,10 @@ async function runOciCliCommand(): Promise<void> {
   const jmesPath = core.getInput('query')
     ? `--query "${core.getInput('query').trim()}"`
     : '';
-  const ociRegion = core.getInput('region')
-    ? `--region "${core.getInput('region').trim()}"`
-    : '';
-
   core.info('Executing Oracle Cloud Infrastructure CLI command');
   const silent = core.getBooleanInput('silent', {required: false});
 
-  const cliCommand = `${cliBin} ${ociRegion} ${jmesPath} ${cliArgs}`;
+  const cliCommand = `${cliBin} ${jmesPath} ${cliArgs}`;
   if (silent) core.setSecret(cliCommand);
 
   const cliResult = await exec.getExecOutput(cliCommand, [], {silent: silent});


### PR DESCRIPTION
Includes updated documentation that explains which OCI CLI environment variables are required.

Signed-off-by: Avi Miller <avi.miller@oracle.com>